### PR TITLE
Add ability to search store by regexp

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -61,7 +61,7 @@ func (s *storeImpl) Delete(key string) {
 	delete(s.objects, key)
 }
 
-// Get returns an object from the store.
+// Get returns a single key-value pair from the store based on its name.
 func (s *storeImpl) Get(key string) (interface{}, bool) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -74,7 +74,7 @@ func (s *storeImpl) Get(key string) (interface{}, bool) {
 	return object.contents, true
 }
 
-// GetByRegex returns objects from the store based on a regexp search.
+// GetByRegex returns a map of key-value pairs from the store based on a regexp search.
 func (s *storeImpl) GetByRegex(expr string) (m map[string]interface{}) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -106,6 +106,36 @@ func TestStore_Get(t *testing.T) {
 	}
 }
 
+// When getting objects in the store by regular expression, the objects should
+// be returned if they exist. Otherwise, return an empty map.
+func TestStore_GetByRegex(t *testing.T) {
+	testCases := []struct {
+		key string
+		val string
+	}{
+		{"foo", "bar"},
+		{"foo.bar", "baz"},
+		{"foo.bar.baz", "quux"},
+		{"bar", "foo"},
+	}
+	var s storeImpl
+	s.objects = map[string]object{}
+
+	for _, tc := range testCases {
+		s.objects[tc.key] = object{contents: tc.val}
+	}
+
+	result := s.GetByRegex("foo.*")
+
+	if l := len(result); l != 3 {
+		t.Fatalf("Expected 3 objects to be returned, got %d", l)
+	}
+
+	if _, ok := result["bar"]; ok {
+		t.Fatalf("Expected result to not contain key 'bar' (but it did!)")
+	}
+}
+
 // When getting all objects in the store, all objects should be returned.
 // Nothing more, nothing less.
 func TestStore_Objects(t *testing.T) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -125,7 +125,11 @@ func TestStore_GetByRegex(t *testing.T) {
 		s.objects[tc.key] = object{contents: tc.val}
 	}
 
-	result := s.GetByRegex("foo.*")
+	result, err := s.GetByRegex("foo.*")
+
+	if err != nil {
+		t.Fatalf("Expected error to be nil (but it wasn't!)")
+	}
 
 	if l := len(result); l != 3 {
 		t.Fatalf("Expected 3 objects to be returned, got %d", l)


### PR DESCRIPTION
This commit adds the ability to return a map of objects from `store`
based on a regular expression. The intended usage is in dcos-metrics,
so that it will be possible to query the store with something like:

```go
s.GetByRegex("dcos.metrics.containers.*")
```