### PR TITLE
dcos/nodeutil: add headers to mesos-id request

### DIFF
--- a/dcos/nodeutil/util.go
+++ b/dcos/nodeutil/util.go
@@ -30,6 +30,13 @@ var defaultStateURL = url.URL{
 	Path:   "/state",
 }
 
+// The key type is unexported to prevent collisions with context keys defined in
+// other packages.
+type key int
+
+// requestHeaderKey is a context key for the user get request headers.
+var requestHeaderKey key = 1
+
 // ErrNodeInfo is an error structure raised by exported functions with meaningful error message.
 type ErrNodeInfo struct {
 	msg string
@@ -289,6 +296,9 @@ func (d *dcosInfo) MesosID(ctx context.Context) (string, error) {
 	}
 
 	if ctx != nil {
+		if header, ok := HeaderFromContext(ctx); ok {
+			req.Header = header
+		}
 		req = req.WithContext(ctx)
 	}
 
@@ -384,4 +394,27 @@ func (d *dcosInfo) ClusterID() (string, error) {
 	}
 
 	return clusterID, nil
+}
+
+// HeaderFromContext returns http.Header from a context if it's found.
+func HeaderFromContext(ctx context.Context) (http.Header, bool) {
+	if ctx == nil {
+		panic("Context cannot be nil")
+	}
+
+	requestValue := ctx.Value(requestHeaderKey)
+	if requestValue == nil {
+		return nil, false
+	}
+
+	header, ok := requestValue.(http.Header)
+	return header, ok
+}
+
+// NewContextWithHeaders adds http.Header to the instance of context.
+func NewContextWithHeaders(ctx context.Context, header http.Header) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, requestHeaderKey, header)
 }

--- a/dcos/nodeutil/util_test.go
+++ b/dcos/nodeutil/util_test.go
@@ -223,3 +223,22 @@ func TestClusterIDInvalidRole(t *testing.T) {
 		}
 	}
 }
+
+func TestContextWithHeaders(t *testing.T) {
+	header := http.Header{}
+	header.Add("TEST", "123")
+
+	ctx := NewContextWithHeaders(nil, header)
+	if ctx == nil {
+		t.Fatal("Context shouldn't be nil")
+	}
+
+	headerFromContext, ok := HeaderFromContext(ctx)
+	if !ok {
+		t.Fatal("header not found in context")
+	}
+
+	if value := headerFromContext.Get("TEST"); value != "123" {
+		t.Fatalf("Expect header `TEST:123`. Got %+v", headerFromContext)
+	}
+}


### PR DESCRIPTION
this is non-breaking change that adds ability for user to pass custom request
headers to `MesosID` function.

This will be used for authorization. Instead of system account, we will make
a request on user's behalf. In order to do so, we need to be able to pass
Authorization header to http request.