### PR TITLE
Add FullOutput() and SimpleFullOutput()

### DIFF
--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -87,8 +87,8 @@ func TestBadReturnCode(t *testing.T) {
 	}
 }
 
-func TestOutput(t *testing.T) {
-	stdout, stderr, code, err := Output(nil, "echo", "hello")
+func TestSimpleFullOutput(t *testing.T) {
+	stdout, stderr, code, err := SimpleFullOutput(time.Second*10, "echo", "hello")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestOutput(t *testing.T) {
 	}
 
 	// Expect error
-	stdout, stderr, code, err = Output(nil, "ec", "hello")
+	stdout, stderr, code, err = SimpleFullOutput(time.Second*10, "ec", "hello")
 	if err == nil {
 		t.Fatal("expect error got nil")
 	}
@@ -126,26 +126,22 @@ func TestOutput(t *testing.T) {
 	}
 }
 
-func TestOutputTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond*100)
-	defer cancel()
-	_, _, _, err := Output(ctx, "sleep", "10")
+func TestSimpleFullOutputTimeout(t *testing.T) {
+	_, _, _, err := SimpleFullOutput(time.Microsecond*100, "sleep", "10")
 	if err == nil {
 		t.Fatal("expect error got nil")
 	}
 }
 
-func TestOutputTimeoutPass(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	_, _, _, err := Output(ctx, "sleep", "1")
+func TestSimpleFullOutputTimeoutPass(t *testing.T) {
+	_, _, _, err := SimpleFullOutput(time.Second*10, "sleep", "1")
 	if err != nil {
 		t.Fatalf("expect nil error. Got %s", err)
 	}
 }
 
 func TestReturnCode(t *testing.T) {
-	_, _, code, err := Output(context.TODO(), "/bin/bash", "./fixture/return-err.sh")
+	_, _, code, err := SimpleFullOutput(time.Second*10, "/bin/bash", "./fixture/return-err.sh")
 	if err != nil {
 		t.Fatalf("expect nil error. Got %s", err)
 	}


### PR DESCRIPTION
This removes exec.Output() and adds FullOutput() and
SimpleFullOutput(). FullOutput() allows the caller to run a customized
Cmd struct instead of a string array. SimpleFullOutput() replaces
Output().

This also adds two convenience functions that can create a Cmd from a
string array: Command() and CommandContext()

See https://github.com/dcos/dcos-diagnostics/pull/8.
