### PR TITLE
dcos/nodeutil: add TaskCanonicalID

### DIFF
--- a/dcos/nodeutil/README.md
+++ b/dcos/nodeutil/README.md
@@ -10,6 +10,8 @@ dcos-go/dcos/nodeutil provides a golang interface to DC/OS cluster.
 - `MesosID(*context.Context)` returns a node's mesos ID. Optionally can accept an instance of Context to control
   request cancellation from a caller.
 - `ClusterID()` returns a UUID of a cluster.
+- `TaskCanonicalID(context.Context, task)` returns a canonical node ID for a given task.
+  This includes the mesos agent, framework, executor and container IDs.
 
 Note: Methods `IsLeader()` and `ClusterID()` will only work on master nodes.
 
@@ -57,4 +59,3 @@ func main() {
     }
 }
 ```
-

--- a/dcos/nodeutil/fixture/state.json
+++ b/dcos/nodeutil/fixture/state.json
@@ -1,0 +1,562 @@
+{
+  "version": "1.5.0",
+  "git_sha": "09df58e9a83dbebf1ae8b32c28cb450294d92612",
+  "build_date": "2017-10-10 20:35:00",
+  "build_time": 1507667700,
+  "build_user": "",
+  "start_time": 1508783004.30362,
+  "elected_time": 1508783004.37298,
+  "id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca",
+  "pid": "master@10.0.4.125:5050",
+  "hostname": "10.0.4.125",
+  "activated_slaves": 2,
+  "deactivated_slaves": 0,
+  "unreachable_slaves": 0,
+  "leader": "master@10.0.4.125:5050",
+  "leader_info": {
+    "id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca",
+    "pid": "master@10.0.4.125:5050",
+    "port": 5050,
+    "hostname": "10.0.4.125"
+  },
+  "cluster": "mnaboka-ewam5mm",
+  "external_log_file": "/var/lib/dcos/mesos/log/mesos-master.log",
+  "flags": {
+    "agent_ping_timeout": "15secs",
+    "slave_removal_rate_limit": "1/20mins",
+    "agent_reregister_timeout": "10mins",
+    "allocation_interval": "1secs",
+    "allocator": "HierarchicalDRF",
+    "authenticate_agents": "false",
+    "authenticate_frameworks": "false",
+    "authenticate_http_frameworks": "false",
+    "authenticate_http_readonly": "false",
+    "authenticate_http_readwrite": "false",
+    "authenticators": "crammd5",
+    "authorizers": "local",
+    "cluster": "mnaboka-ewam5mm",
+    "external_log_file": "/var/lib/dcos/mesos/log/mesos-master.log",
+    "fair_sharing_excluded_resource_names": "{ gpus }",
+    "filter_gpu_resources": "true",
+    "framework_sorter": "drf",
+    "help": "false",
+    "hostname_lookup": "false",
+    "http_authenticators": "basic",
+    "initialize_driver_logging": "true",
+    "ip_discovery_command": "/opt/mesosphere/bin/detect_ip",
+    "log_auto_initialize": "true",
+    "logbufsecs": "0",
+    "logging_level": "INFO",
+    "max_slave_ping_timeouts": "20",
+    "max_completed_frameworks": "50",
+    "max_completed_tasks_per_framework": "1000",
+    "max_unreachable_tasks_per_framework": "1000",
+    "modules_dir": "/opt/mesosphere/etc/mesos-master-modules",
+    "offer_timeout": "2mins",
+    "port": "5050",
+    "quiet": "false",
+    "quorum": "1",
+    "recovery_agent_removal_limit": "100%",
+    "registry": "replicated_log",
+    "registry_fetch_timeout": "1mins",
+    "registry_gc_interval": "15mins",
+    "registry_max_agent_age": "2weeks",
+    "registry_max_agent_count": "102400",
+    "registry_store_timeout": "1mins",
+    "registry_strict": "false",
+    "root_submissions": "true",
+    "user_sorter": "drf",
+    "version": "false",
+    "webui_dir": "/opt/mesosphere/packages/mesos--7d58751d9054e9ef0209751d3a849ecdecfe322e/share/mesos/webui",
+    "weights": "",
+    "work_dir": "/var/lib/dcos/mesos/master",
+    "zk": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos",
+    "zk_session_timeout": "10secs"
+  },
+  "slaves": [
+    {
+      "id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1",
+      "hostname": "10.0.0.157",
+      "port": 5051,
+      "attributes": {},
+      "pid": "slave(1)@10.0.0.157:5051",
+      "registered_time": 1508783065.27533,
+      "resources": {
+        "disk": 138588,
+        "mem": 15026,
+        "gpus": 0,
+        "cpus": 4,
+        "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+      },
+      "used_resources": {
+        "disk": 10,
+        "mem": 544,
+        "gpus": 0,
+        "cpus": 0.5
+      },
+      "offered_resources": {
+        "disk": 0,
+        "mem": 0,
+        "gpus": 0,
+        "cpus": 0
+      },
+      "reserved_resources": {},
+      "unreserved_resources": {
+        "disk": 138588,
+        "mem": 15026,
+        "gpus": 0,
+        "cpus": 4,
+        "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+      },
+      "active": true,
+      "version": "1.5.0",
+      "capabilities": [
+        "MULTI_ROLE",
+        "HIERARCHICAL_ROLE",
+        "RESERVATION_REFINEMENT"
+      ]
+    },
+    {
+      "id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S0",
+      "hostname": "10.0.6.133",
+      "port": 5051,
+      "attributes": {
+        "public_ip": "true"
+      },
+      "pid": "slave(1)@10.0.6.133:5051",
+      "registered_time": 1508783036.16545,
+      "resources": {
+        "disk": 138588,
+        "mem": 15026,
+        "gpus": 0,
+        "cpus": 4,
+        "ports": "[1-21, 23-5050, 5052-32000]"
+      },
+      "used_resources": {
+        "disk": 0,
+        "mem": 0,
+        "gpus": 0,
+        "cpus": 0
+      },
+      "offered_resources": {
+        "disk": 0,
+        "mem": 0,
+        "gpus": 0,
+        "cpus": 0
+      },
+      "reserved_resources": {
+        "slave_public": {
+          "disk": 138588,
+          "mem": 15026,
+          "gpus": 0,
+          "cpus": 4,
+          "ports": "[1-21, 23-5050, 5052-32000]"
+        }
+      },
+      "unreserved_resources": {
+        "disk": 0,
+        "mem": 0,
+        "gpus": 0,
+        "cpus": 0
+      },
+      "active": true,
+      "version": "1.5.0",
+      "capabilities": [
+        "MULTI_ROLE",
+        "HIERARCHICAL_ROLE",
+        "RESERVATION_REFINEMENT"
+      ]
+    }
+  ],
+  "recovered_slaves": [],
+  "frameworks": [
+    {
+      "id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0001",
+      "name": "metronome",
+      "pid": "scheduler-96e1fbb5-bace-4bbd-9ef1-070a15ffcdc6@10.0.4.125:15201",
+      "used_resources": {
+        "disk": 0,
+        "mem": 0,
+        "gpus": 0,
+        "cpus": 0
+      },
+      "offered_resources": {
+        "disk": 0,
+        "mem": 0,
+        "gpus": 0,
+        "cpus": 0
+      },
+      "capabilities": [],
+      "hostname": "10.0.4.125",
+      "webui_url": "http://10.0.4.125:9000",
+      "active": true,
+      "connected": true,
+      "recovered": false,
+      "user": "root",
+      "failover_timeout": 604800000,
+      "checkpoint": true,
+      "registered_time": 1508783041.27185,
+      "unregistered_time": 0,
+      "resources": {
+        "disk": 0,
+        "mem": 0,
+        "gpus": 0,
+        "cpus": 0
+      },
+      "role": "*",
+      "tasks": [],
+      "unreachable_tasks": [],
+      "completed_tasks": [],
+      "offers": [],
+      "executors": []
+    },
+    {
+      "id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+      "name": "marathon",
+      "pid": "scheduler-b34a3afe-6acd-435c-a2f6-81ccc654daee@10.0.4.125:15101",
+      "used_resources": {
+        "disk": 10,
+        "mem": 544,
+        "gpus": 0,
+        "cpus": 0.5
+      },
+      "offered_resources": {
+        "disk": 0,
+        "mem": 0,
+        "gpus": 0,
+        "cpus": 0
+      },
+      "capabilities": [
+        "TASK_KILLING_STATE",
+        "GPU_RESOURCES",
+        "PARTITION_AWARE"
+      ],
+      "hostname": "10.0.4.125",
+      "webui_url": "http://10.0.4.125:8080",
+      "active": true,
+      "connected": true,
+      "recovered": false,
+      "user": "root",
+      "failover_timeout": 604800,
+      "checkpoint": true,
+      "registered_time": 1508783026.20089,
+      "unregistered_time": 0,
+      "principal": "dcos_marathon",
+      "resources": {
+        "disk": 10,
+        "mem": 544,
+        "gpus": 0,
+        "cpus": 0.5
+      },
+      "role": "slave_public",
+      "tasks": [
+        {
+          "id": "parent-pod.instance-da6ef080-b81f-11e7-a9ac-52ad791ffaa8.container-2",
+          "name": "container-2",
+          "framework_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+          "executor_id": "instance-parent-pod.da6ef080-b81f-11e7-a9ac-52ad791ffaa8",
+          "slave_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1",
+          "state": "TASK_RUNNING",
+          "resources": {
+            "disk": 0,
+            "mem": 128,
+            "gpus": 0,
+            "cpus": 0.1
+          },
+          "role": "slave_public",
+          "statuses": [
+            {
+              "state": "TASK_RUNNING",
+              "timestamp": 1508783261.51415,
+              "container_status": {
+                "container_id": {
+                  "value": "0f79cb5f-f946-4a65-97ec-e84157216311",
+                  "parent": {
+                    "value": "1eb53d03-e8f2-4de7-8a51-be17b42a3a29"
+                  }
+                },
+                "network_infos": [
+                  {
+                    "ip_addresses": [
+                      {
+                        "protocol": "IPv4",
+                        "ip_address": "10.0.0.157"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "discovery": {
+            "visibility": "FRAMEWORK",
+            "name": "parent-pod",
+            "ports": {}
+          }
+        },
+        {
+          "id": "parent-pod.instance-da6ef080-b81f-11e7-a9ac-52ad791ffaa8.container-1",
+          "name": "container-1",
+          "framework_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+          "executor_id": "instance-parent-pod.da6ef080-b81f-11e7-a9ac-52ad791ffaa8",
+          "slave_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1",
+          "state": "TASK_RUNNING",
+          "resources": {
+            "disk": 0,
+            "mem": 128,
+            "gpus": 0,
+            "cpus": 0.1
+          },
+          "role": "slave_public",
+          "statuses": [
+            {
+              "state": "TASK_RUNNING",
+              "timestamp": 1508783261.5131,
+              "container_status": {
+                "container_id": {
+                  "value": "e7ed292a-8390-4da4-8c2a-c13b554e2c2a",
+                  "parent": {
+                    "value": "1eb53d03-e8f2-4de7-8a51-be17b42a3a29"
+                  }
+                },
+                "network_infos": [
+                  {
+                    "ip_addresses": [
+                      {
+                        "protocol": "IPv4",
+                        "ip_address": "10.0.0.157"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "discovery": {
+            "visibility": "FRAMEWORK",
+            "name": "parent-pod",
+            "ports": {}
+          }
+        },
+        {
+          "id": "single-mesos-container.c1f5ae3f-b81f-11e7-a9ac-52ad791ffaa8",
+          "name": "single-mesos-container",
+          "framework_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+          "executor_id": "",
+          "slave_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1",
+          "state": "TASK_RUNNING",
+          "resources": {
+            "disk": 0,
+            "mem": 128,
+            "gpus": 0,
+            "cpus": 0.1
+          },
+          "role": "slave_public",
+          "statuses": [
+            {
+              "state": "TASK_RUNNING",
+              "timestamp": 1508783219.92384,
+              "container_status": {
+                "container_id": {
+                  "value": "1a69d257-48ca-4d3b-aead-332ad881fcc7"
+                },
+                "network_infos": [
+                  {
+                    "ip_addresses": [
+                      {
+                        "protocol": "IPv4",
+                        "ip_address": "10.0.0.157"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "discovery": {
+            "visibility": "FRAMEWORK",
+            "name": "single-mesos-container",
+            "ports": {}
+          },
+          "container": {
+            "type": "MESOS",
+            "mesos": {}
+          }
+        },
+        {
+          "id": "test123-123",
+          "name": "test123",
+          "framework_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+          "executor_id": "",
+          "slave_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1",
+          "state": "TASK_RUNNING",
+          "resources": {
+            "disk": 0,
+            "mem": 128,
+            "gpus": 0,
+            "cpus": 0.1
+          },
+          "role": "slave_public",
+          "statuses": [
+            {
+              "state": "TASK_RUNNING",
+              "timestamp": 1508783219.92384,
+              "container_status": {
+                "container_id": {
+                  "value": "1a69d257-48ca-4d3b-aead-332ad881fcc7"
+                },
+                "network_infos": [
+                  {
+                    "ip_addresses": [
+                      {
+                        "protocol": "IPv4",
+                        "ip_address": "10.0.0.157"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "discovery": {
+            "visibility": "FRAMEWORK",
+            "name": "test123",
+            "ports": {}
+          },
+          "container": {
+            "type": "MESOS",
+            "mesos": {}
+          }
+        },
+        {
+          "id": "test123-345",
+          "name": "test123",
+          "framework_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+          "executor_id": "",
+          "slave_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1",
+          "state": "TASK_RUNNING",
+          "resources": {
+            "disk": 0,
+            "mem": 128,
+            "gpus": 0,
+            "cpus": 0.1
+          },
+          "role": "slave_public",
+          "statuses": [
+            {
+              "state": "TASK_RUNNING",
+              "timestamp": 1508783219.92384,
+              "container_status": {
+                "container_id": {
+                  "value": "1a69d257-48ca-4d3b-aead-332ad881fcc7"
+                },
+                "network_infos": [
+                  {
+                    "ip_addresses": [
+                      {
+                        "protocol": "IPv4",
+                        "ip_address": "10.0.0.157"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "discovery": {
+            "visibility": "FRAMEWORK",
+            "name": "test123",
+            "ports": {}
+          },
+          "container": {
+            "type": "MESOS",
+            "mesos": {}
+          }
+        },
+        {
+          "id": "single-docker-container.ac0b2d2e-b81f-11e7-a9ac-52ad791ffaa8",
+          "name": "single-docker-container",
+          "framework_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+          "executor_id": "",
+          "slave_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1",
+          "state": "TASK_RUNNING",
+          "resources": {
+            "disk": 0,
+            "mem": 128,
+            "gpus": 0,
+            "cpus": 0.1
+          },
+          "role": "slave_public",
+          "statuses": [
+            {
+              "state": "TASK_RUNNING",
+              "timestamp": 1508783209.34044,
+              "container_status": {
+                "container_id": {
+                  "value": "8498bfde-fc85-4421-b7bf-28bb9a13b154"
+                },
+                "network_infos": [
+                  {
+                    "ip_addresses": [
+                      {
+                        "protocol": "IPv4",
+                        "ip_address": "10.0.0.157"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "discovery": {
+            "visibility": "FRAMEWORK",
+            "name": "single-docker-container",
+            "ports": {}
+          },
+          "container": {
+            "type": "DOCKER",
+            "docker": {
+              "image": "golang",
+              "network": "HOST",
+              "privileged": false,
+              "parameters": [
+                {
+                  "key": "label",
+                  "value": "MESOS_TASK_ID=single-docker-container.ac0b2d2e-b81f-11e7-a9ac-52ad791ffaa8"
+                }
+              ],
+              "force_pull_image": false
+            }
+          }
+        }
+      ],
+      "unreachable_tasks": [],
+      "completed_tasks": [],
+      "offers": [],
+      "executors": [
+        {
+          "executor_id": "instance-parent-pod.da6ef080-b81f-11e7-a9ac-52ad791ffaa8",
+          "name": "",
+          "framework_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+          "command": {
+            "argv": [],
+            "uris": []
+          },
+          "resources": {
+            "disk": 10,
+            "mem": 32,
+            "gpus": 0,
+            "cpus": 0.1
+          },
+          "role": "slave_public",
+          "labels": [],
+          "type": "DEFAULT",
+          "slave_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1"
+        }
+      ]
+    }
+  ],
+  "completed_frameworks": [],
+  "orphan_tasks": [],
+  "unregistered_frameworks": []
+}

--- a/dcos/nodeutil/mesos.go
+++ b/dcos/nodeutil/mesos.go
@@ -1,5 +1,10 @@
 package nodeutil
 
+import "errors"
+
+// ErrContainerIDNotFound is returned by ContainerIDs() function if the container id is not set.
+var ErrContainerIDNotFound = errors.New("invalid task. Container ID not found")
+
 // State stands for mesos state.json available via /mesos/master/state.json
 type State struct {
 	ID         string      `json:"id"`
@@ -34,6 +39,45 @@ type Task struct {
 	State       string `json:"state"`
 	Role        string `json:"role"`
 
-	Statuses []struct {
-	} `json:"statuses"`
+	Statuses []Status `json:"statuses"`
+}
+
+// Status is a field in state.json
+type Status struct {
+	ContainerStatus ContainerStatus `json:"container_status"`
+}
+
+// ContainerStatus is a field in state.json
+type ContainerStatus struct {
+	ContainerID NestedValue `json:"container_id"`
+}
+
+// NestedValue represents a nested container ID. The value is the actual container ID
+// and Parent is a reference to another NestedValue structure.
+type NestedValue struct {
+	Value  string       `json:"value"`
+	Parent *NestedValue `json:"parent"`
+}
+
+// ContainerIDs returns a slice of container ids , starting with the current,
+// and then appending the parent container ids.
+func (t Task) ContainerIDs() (containerIDs []string, err error) {
+	for _, status := range t.Statuses {
+		containerID := status.ContainerStatus.ContainerID.Value
+		if containerID == "" {
+			return nil, ErrContainerIDNotFound
+		}
+		containerIDs = append(containerIDs, containerID)
+
+		parent := status.ContainerStatus.ContainerID.Parent
+		for parent != nil {
+			containerIDs = append(containerIDs, parent.Value)
+			parent = parent.Parent
+		}
+	}
+
+	if len(containerIDs) == 0 {
+		return nil, ErrContainerIDNotFound
+	}
+	return containerIDs, nil
 }

--- a/dcos/nodeutil/mesos.go
+++ b/dcos/nodeutil/mesos.go
@@ -1,0 +1,39 @@
+package nodeutil
+
+// State stands for mesos state.json available via /mesos/master/state.json
+type State struct {
+	ID         string      `json:"id"`
+	Slaves     []Slave     `json:"slaves"`
+	Frameworks []Framework `json:"frameworks"`
+}
+
+// Slave is a field in state.json
+type Slave struct {
+	ID       string `json:"id"`
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port"`
+	Pid      string `json:"pid"`
+}
+
+// Framework is a field in state.json
+type Framework struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	PID   string `json:"pid"`
+	Role  string `json:"role"`
+	Tasks []Task `json:"tasks"`
+}
+
+// Task is a field in state.json
+type Task struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	FrameworkID string `json:"framework_id"`
+	ExecutorID  string `json:"executor_id"`
+	SlaveID     string `json:"slave_id"`
+	State       string `json:"state"`
+	Role        string `json:"role"`
+
+	Statuses []struct {
+	} `json:"statuses"`
+}

--- a/dcos/nodeutil/mesos_test.go
+++ b/dcos/nodeutil/mesos_test.go
@@ -1,0 +1,84 @@
+package nodeutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTaskContainerID(t *testing.T) {
+	status := Status{
+		ContainerStatus: ContainerStatus{
+			ContainerID: NestedValue{
+				Value: "test",
+			},
+		},
+	}
+
+	task := Task{
+		Statuses: []Status{status},
+	}
+
+	ids, err := task.ContainerIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Join(ids, "") != "test" {
+		t.Fatalf("expect container id test. Got %s", ids)
+	}
+}
+
+func TestTaskNestedContainerID(t *testing.T) {
+	status := Status{
+		ContainerStatus: ContainerStatus{
+			ContainerID: NestedValue{
+				Value: "test",
+				Parent: &NestedValue{
+					Value: "test2",
+				},
+			},
+		},
+	}
+
+	task := Task{
+		Statuses: []Status{status},
+	}
+
+	ids, err := task.ContainerIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Join(ids, "-") != "test-test2" {
+		t.Fatalf("expect 2 ids: test, test2. Got %s", ids)
+	}
+}
+
+func TestTaskNestedContainerID2(t *testing.T) {
+	status := Status{
+		ContainerStatus: ContainerStatus{
+			ContainerID: NestedValue{
+				Value: "test",
+				Parent: &NestedValue{
+					Value: "test2",
+					Parent: &NestedValue{
+						Value: "test3",
+					},
+				},
+			},
+		},
+	}
+
+	task := Task{
+		Statuses: []Status{status},
+	}
+
+	ids, err := task.ContainerIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Join(ids, "-") != "test-test2-test3" {
+		t.Fatalf("expect 2 ids: test, test2, test3. Got %s", ids)
+	}
+}

--- a/dcos/nodeutil/util_test.go
+++ b/dcos/nodeutil/util_test.go
@@ -7,7 +7,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"context"
 	"github.com/dcos/dcos-go/dcos"
+	"io/ioutil"
+	"strings"
 )
 
 func TestDetectIP(t *testing.T) {
@@ -156,6 +159,95 @@ func TestClusterIDInvalidRole(t *testing.T) {
 			t.Fatalf("Expect error of type ErrNodeInfo. Got %s", err)
 		}
 	}
+}
+
+func TestMesosRuntimeShortCanonicalID(t *testing.T) {
+	expectedAgentID := "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1"
+	expectedFrameworkID := "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000"
+	expectedExecutorID := "single-mesos-container.c1f5ae3f-b81f-11e7-a9ac-52ad791ffaa8"
+	expectedContainerID := "1a69d257-48ca-4d3b-aead-332ad881fcc7"
+
+	if err := testCanonicalID("single-mesos-container", expectedAgentID, expectedFrameworkID, expectedExecutorID, expectedContainerID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMesosRuntimeLongCanonicalID(t *testing.T) {
+	expectedAgentID := "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1"
+	expectedFrameworkID := "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000"
+	expectedExecutorID := "single-mesos-container.c1f5ae3f-b81f-11e7-a9ac-52ad791ffaa8"
+	expectedContainerID := "1a69d257-48ca-4d3b-aead-332ad881fcc7"
+	if err := testCanonicalID("single-mesos-container.c1f5ae3f-b81f-11e7-a9ac-52ad791ffaa8", expectedAgentID, expectedFrameworkID, expectedExecutorID, expectedContainerID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCanonicalTaskIDNotFound(t *testing.T) {
+	if err := testCanonicalID("foobar", "", "", "", ""); err != ErrTaskNotFound {
+		t.Fatalf("error must be %s. Got %s", ErrTaskNotFound, err)
+	}
+}
+
+func TestPodCanonicalID(t *testing.T) {
+	expectedAgentID := "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1"
+	expectedFrameworkID := "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000"
+	expectedExecutorID := "instance-parent-pod.da6ef080-b81f-11e7-a9ac-52ad791ffaa8"
+	expectedContainerID := "e7ed292a-8390-4da4-8c2a-c13b554e2c2a-1eb53d03-e8f2-4de7-8a51-be17b42a3a29"
+	if err := testCanonicalID("container-1", expectedAgentID, expectedFrameworkID, expectedExecutorID, expectedContainerID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCanonicalIDSameNameTasks(t *testing.T) {
+	err := testCanonicalID("test123", "", "", "", "")
+	if err == nil {
+		t.Fatal("expecting error. Got nil")
+	}
+
+	expectedError := "found more then 1 task with name test123: [test123-123 test123-345]"
+	if err.Error() != expectedError {
+		t.Fatalf("expect error %s. Got %s", expectedError, err)
+	}
+}
+
+func testCanonicalID(task, expectedAgentID, expectedFrameworkID, expectedExecutorID, expectedContainerID string) error {
+	state, err := ioutil.ReadFile("fixture/state.json")
+	if err != nil {
+		return err
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, string(state))
+	}))
+	defer ts.Close()
+
+	d, err := NewNodeInfo(&http.Client{}, dcos.RoleMaster, OptionMesosStateURL(ts.URL))
+	if err != nil {
+		return err
+	}
+
+	cID, err := d.TaskCanonicalID(context.TODO(), task)
+	if err != nil {
+		return err
+	}
+
+	if cID.AgentID != expectedAgentID {
+		return fmt.Errorf("expecting agent id %s. Got %s", expectedAgentID, cID.AgentID)
+	}
+
+	if cID.FrameworkID != expectedFrameworkID {
+		return fmt.Errorf("expecting framework id %s. Got %s", expectedFrameworkID, cID.FrameworkID)
+	}
+
+	if cID.ExecutorID != expectedExecutorID {
+		return fmt.Errorf("expecting executor id %s. Got %s", expectedExecutorID, cID.ExecutorID)
+	}
+
+	if strings.Join(cID.ContainerIDs, "-") != expectedContainerID {
+		return fmt.Errorf("expecting task id: %s. Got %s", expectedContainerID, cID.ContainerIDs)
+	}
+
+	return nil
 }
 
 func TestContextWithHeaders(t *testing.T) {


### PR DESCRIPTION
# Add TaskCanonicalID method in dcosInfo. This method return information about task including the framework, executor and agent IDs.
## Checklist
- [X] ~80% unit test coverage?
- [x] Updated [README.md](README.md)?
- [X] Completed sections of this PR template?
- [X] Edited all sections [IN BRACKETS]

## Overview of Change
Both `dcos-metrics` and `dcos-log` need a way to find metadata associated with a task.
User should only know the task ID, the rest of metadata must be looked up in state.json

### Changelog [optional]
- [] [optional list]

## Affected Usage
Adding a new method should not affect any existing libraries.
