### PR TITLE
http/transport: update code to jwt-go 3.1.0

### DIFF
--- a/dcos/http/transport/README.md
+++ b/dcos/http/transport/README.md
@@ -1,7 +1,6 @@
 # dcos-go/jwt/transport
 
 #### Warning.
-- package works only with `github.com/dgrijalva/jwt-go` `v2.6.0`. Please make sure you vendor the right version.
 - package breaks `RoundTripper` interface spec defined in `https://golang.org/pkg/net/http/#RoundTripper`
   by mutating request instance.
 

--- a/dcos/http/transport/option.go
+++ b/dcos/http/transport/option.go
@@ -20,6 +20,8 @@ import (
 	"io/ioutil"
 	"os"
 	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 var (
@@ -86,7 +88,11 @@ func OptionCredentials(uid, secret, loginEndpoint string) OptionRoundtripperFunc
 			return ErrInvalidCredentials
 		}
 		j.uid = uid
-		j.secret = secret
+		var err error
+		j.secret, err = jwt.ParseRSAPrivateKeyFromPEM([]byte(secret))
+		if err != nil {
+			return ErrInvalidCredentials
+		}
 		j.loginEndpoint = loginEndpoint
 		return nil
 	}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -96,7 +96,7 @@ function main {
     # Dependencies required for testing
     go get -u github.com/kardianos/govendor
     govendor init
-    govendor fetch github.com/dgrijalva/jwt-go/^::gopkg.in/dgrijalva/jwt-go.v2
+    govendor fetch github.com/dgrijalva/jwt-go@v3.1.0
     govendor fetch github.com/pkg/errors
 
     _gofmt


### PR DESCRIPTION
#  update code to jwt-go 3.1.0
## Checklist
- [x] ~80% unit test coverage?
- [x] Updated [README.md](README.md)?
- [x] Completed sections of this PR template?
- [x] Edited all sections [IN BRACKETS]

## Overview of Change
Dependencies of this library had to pin jwt-go to an old version. This is not necessary anymore.

## Affected Usage
- Dependencies now need to move from jwt-go 2.6.0 to 3.1.0
