### PR TITLE
http/transport: use more maintained gopkg.in/square/go-jose.v2

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -96,7 +96,8 @@ function main {
     # Dependencies required for testing
     go get -u github.com/kardianos/govendor
     govendor init
-    govendor fetch github.com/dgrijalva/jwt-go@v3.1.0
+    govendor fetch gopkg.in/square/go-jose.v2
+    govendor fetch gopkg.in/square/go-jose.v2/jwt
     govendor fetch github.com/pkg/errors
 
     _gofmt


### PR DESCRIPTION
# use more maintained gopkg.in/square/go-jose.v2 for JWT related things

## Checklist
- [x] ~80% unit test coverage?
- [] Updated [README.md](README.md)?
- [x] Completed sections of this PR template?
- [x] Edited all sections [IN BRACKETS]

## Overview of Change
1. go-jose v2 is widely used and actively maintained
2. I need to use other functionality from go-jose such as jwk. We probably don't want to always include two libraries
