### PR TITLE
make possible to get CanonicalID for completed tasks

### DIFF
--- a/dcos/nodeutil/fixture/state.json
+++ b/dcos/nodeutil/fixture/state.json
@@ -531,7 +531,64 @@
         }
       ],
       "unreachable_tasks": [],
-      "completed_tasks": [],
+      "completed_tasks": [
+        {
+          "id": "single-docker-container.ac0b2d2e-b81f-11e7-a9ac-52ad791ffaa8",
+          "name": "single-docker-completed",
+          "framework_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-0000",
+          "executor_id": "",
+          "slave_id": "db10f9b1-5b82-4187-aa47-4fbcefc7cdca-S1",
+          "state": "TASK_RUNNING",
+          "resources": {
+            "disk": 0,
+            "mem": 128,
+            "gpus": 0,
+            "cpus": 0.1
+          },
+          "role": "slave_public",
+          "statuses": [
+            {
+              "state": "TASK_RUNNING",
+              "timestamp": 1508783209.34044,
+              "container_status": {
+                "container_id": {
+                  "value": "8498bfde-fc85-4421-b7bf-28bb9a13b154"
+                },
+                "network_infos": [
+                  {
+                    "ip_addresses": [
+                      {
+                        "protocol": "IPv4",
+                        "ip_address": "10.0.0.157"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "discovery": {
+            "visibility": "FRAMEWORK",
+            "name": "single-docker-container",
+            "ports": {}
+          },
+          "container": {
+            "type": "DOCKER",
+            "docker": {
+              "image": "golang",
+              "network": "HOST",
+              "privileged": false,
+              "parameters": [
+                {
+                  "key": "label",
+                  "value": "MESOS_TASK_ID=single-docker-container.ac0b2d2e-b81f-11e7-a9ac-52ad791ffaa8"
+                }
+              ],
+              "force_pull_image": false
+            }
+          }
+        }
+      ],
       "offers": [],
       "executors": [
         {

--- a/dcos/nodeutil/mesos.go
+++ b/dcos/nodeutil/mesos.go
@@ -22,11 +22,12 @@ type Slave struct {
 
 // Framework is a field in state.json
 type Framework struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	PID   string `json:"pid"`
-	Role  string `json:"role"`
-	Tasks []Task `json:"tasks"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	PID            string `json:"pid"`
+	Role           string `json:"role"`
+	Tasks          []Task `json:"tasks"`
+	CompletedTasks []Task `json:"completed_tasks"`
 }
 
 // Task is a field in state.json


### PR DESCRIPTION
# [Add ability to get the canonical ID for already completed tasks ]
## Checklist
- [X] ~80% unit test coverage?
- [ ] Updated [README.md](README.md)?
- [X] Completed sections of this PR template?
- [X] Edited all sections [IN BRACKETS]

## Overview of Change
in dcos-log v2 the user will want to access the logs for the completed tasks.

### Changelog [optional]
N/A

## Affected Usage
N/A
