### PR TITLE
zkstore: allow explicit create by passing Version(-1) to Put

### DIFF
--- a/zkstore/README.md
+++ b/zkstore/README.md
@@ -47,4 +47,4 @@ When performing a Get, the Store will set the `Version` on the returned Item.  T
 
 If this is set on an item's Ident property when performing a mutating operation, it will ensure that the item that is updated is specifically that version when setting it.  If another client happened to set the item before the first client was able to do so, the library will return the `ErrVersionConflict` error.  At this point, the client may choose to do another read and try again.
 
-If the `Item.Ident.Version` is set to -1 when passing an Item to Put() it is assumed that this Put() must create the item and it will return ErrVersionConflict if the node already exists. If no Version is specified, Put will create the node if it doesn't already exist or ignore and overwrite the existing Item with the new one if it does.
+If the `Item.Ident.Version` is set to `NoPriorVersion` when passing an Item to Put() it is assumed that this Put() must create the item and it will return ErrVersionConflict if the node already exists. If no Version is specified, Put will create the node if it doesn't already exist or ignore and overwrite the existing Item with the new one if it does.

--- a/zkstore/README.md
+++ b/zkstore/README.md
@@ -46,3 +46,5 @@ Part of an item's Ident is a `Version` field called `Version`.
 When performing a Get, the Store will set the `Version` on the returned Item.  This allows the client to specify that version when performing a subsequent mutating operation.
 
 If this is set on an item's Ident property when performing a mutating operation, it will ensure that the item that is updated is specifically that version when setting it.  If another client happened to set the item before the first client was able to do so, the library will return the `ErrVersionConflict` error.  At this point, the client may choose to do another read and try again.
+
+If the `Item.Ident.Version` is set to -1 when passing an Item to Put() it is assumed that this Put() must create the item and it will return ErrVersionConflict if the node already exists. If no Version is specified, Put will create the node if it doesn't already exist or ignore and overwrite the existing Item with the new one if it does.

--- a/zkstore/store.go
+++ b/zkstore/store.go
@@ -76,7 +76,7 @@ func NewStore(connector Connector, opts ...StoreOpt) (*Store, error) {
 // item (with no Variant) does not exist yet, the current item will be
 // created as well, with the same data as the specified Item.
 //
-// Returns ErrConflict if there is a Version mismatch between the item given
+// Returns ErrVersionConflict if there is a Version mismatch between the item given
 // and the version of the data currently stored. This check is not performed
 // if there is no Version set for the given item.
 func (s *Store) Put(item Item) (Ident, error) {
@@ -132,13 +132,17 @@ func (s *Store) Put(item Item) (Ident, error) {
 	return item.Ident, err
 }
 
+// NoPriorVersion tells Put that we're expecting to create a new znode for a particular item,
+// not to update an existing item. If znode already exists, then ErrVersionConflict may be returned.
+const NoPriorVersion = -1
+
 // creatingNewItem returns whether or not the Item version dictates that this
 // item should be created and an error should be returned if it already exists
 // in ZK. It returns true if and only if the Version is explicitly set to -1
 // when passed to Put().
 func creatingNewItem(item Item) bool {
 	v, isSet := item.Ident.Version.Value()
-	return isSet && v == -1
+	return isSet && v == NoPriorVersion
 }
 
 // setFully sets data for a path, creating any parents nodes as necessary.

--- a/zkstore/store_test.go
+++ b/zkstore/store_test.go
@@ -276,21 +276,21 @@ func TestVersionSetOnCreate(t *testing.T) {
 	ident, err := store.Put(item)
 	require.Equal(ErrVersionConflict, err)
 
-	// this should succeed because the item does not exist yet and version == -1
+	// this should succeed because the item does not exist yet and version == NoPriorVersion
 	item = newItem()
-	item.Ident.Version = NewVersion(-1)
+	item.Ident.Version = NewVersion(NoPriorVersion)
 	ident, err = store.Put(item)
 	require.NoError(err)
 	require.EqualValues(0, ident.actualVersion())
 
-	// this should fail because the item was already created with version == -1.
+	// this should fail because the item was already created.
 	item = newItem()
-	item.Ident.Version = NewVersion(-1)
+	item.Ident.Version = NewVersion(NoPriorVersion)
 	ident, err = store.Put(item)
 	require.Equal(ErrVersionConflict, err)
 
-	// this should succeed because the item already exists and was created
-	// with version==-1 which means currently its version==0.
+	// this should succeed because the item already exists and has not been
+	// subsequently updated which means currently its version==0.
 	item = newItem()
 	item.Ident.Version = NewVersion(0)
 	ident, err = store.Put(item)

--- a/zkstore/validate.go
+++ b/zkstore/validate.go
@@ -34,7 +34,7 @@ func ValidateNamed(name string, required bool) error {
 	return nil
 }
 
-// ValidateCategory: a category is required, and can look like a path or not.
+// ValidateCategory checks that a category is required, and can look like a path or not.
 func ValidateCategory(name string) error {
 	if strings.TrimSpace(name) == "" {
 		return errBadCategory


### PR DESCRIPTION
# zkstore: Allow explicit create by passing Version(-1) to Put.
## Checklist
- [x] ~80% unit test coverage?
- [x] Updated [README.md](README.md)?
- [x] Completed sections of this PR template?
- [x] Edited all sections [IN BRACKETS]

## Overview of Change
When using the zkstore API it is sometimes useful to know that a given Item is being created for the first time. Currently similar functionality is available by passing a specific Version to the Put function which returns ErrVersionConflict if the specified version is not the latest one. However, this is only possible when the Item already exists in the store, not when it is first created.

This PR extends the logic around ErrVersionConflict on Put by allowing the caller to explicitly specify Version(-1) to signal that an ErrVersionConflict error should be returned if the Item already exists. The standard way to signal "overwrite the latest version, irrespective of its previous value" is to simply not specify the `Item.Ident.Version` field.

### Changelog [optional]
- zkstore: allow explicit create by passing Version(-1) to Put

## Affected Usage

This is backwards-compatible as setting the Version to -1 was previously not allowed.
