### PR TITLE
Update Makefile and test script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9.3
 
 # libltdl7 is needed to run the Docker CLI
 RUN apt-get update \

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -154,6 +154,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "550cf199ddc37e2a281bf4e7b1ed18aa61d6a0d00a16dc34ddf29e4ae2223752"
+  inputs-digest = "35b1a5cc21c4d0ccdc64e2f924aa70ebabf325285929262ef9572e42bb76983d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: test
+.PHONY: all
 all: clean test
 
+.PHONY: clean
 clean:
 	rm -rf ./build
-	rm -rf ./vendor
 
+.PHONY: test
 test:
 	bash -c './scripts/test.sh'

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -93,13 +93,6 @@ function _unittest_with_coverage {
 
 # Main.
 function main {
-    # Dependencies required for testing
-    go get -u github.com/kardianos/govendor
-    govendor init
-    govendor fetch gopkg.in/square/go-jose.v2
-    govendor fetch gopkg.in/square/go-jose.v2/jwt
-    govendor fetch github.com/pkg/errors
-
     _gofmt
     _goimports
     _golint


### PR DESCRIPTION
# Update Makefile and test script

Now that the project is using dep, the test script no longer needs to use govendor (hopefully)

JIRA: https://jira.mesosphere.com/browse/DCOS-21365

Also, some general housekeeping was done as a part of this PR.

## Checklist
* [ ] ~80% unit test coverage? : N/A
* [ ] Updated [README.md](README.md)? N/A
* [x] Completed sections of this PR template?
* [x] Edited all sections [IN BRACKETS]

## Overview of Change

JIRA: https://jira.mesosphere.com/browse/DCOS-21365

The idea is to try and standardize the build mechanics across the cluster ops projects.

## Affected Usage
This should have no change re: usage.