### PR TITLE
elector: API tweaks and deadlock fix

### DIFF
--- a/elector/connector.go
+++ b/elector/connector.go
@@ -4,11 +4,54 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 )
 
-// Connector specifies a way to connect to ZK
+// Connector specifies a way to connect to ZK.
 type Connector interface {
 	// Connect returns a ZK connection and events channel
-	Connect() (*zk.Conn, <-chan zk.Event, error)
+	Connect() (Conn, <-chan zk.Event, error)
 
 	// Close should ensure the ZK connection is closed.
 	Close() error
+}
+
+// Conn represents a connection to ZK.
+type Conn interface {
+	Get(path string) ([]byte, *zk.Stat, error)
+	Exists(path string) (bool, *zk.Stat, error)
+	Create(path string, data []byte, flags int32, acl []zk.ACL) (string, error)
+	CreateProtectedEphemeralSequential(path string, data []byte, acl []zk.ACL) (string, error)
+	ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error)
+}
+
+// ConnAdapter represents a connection to ZK.
+type ConnAdapter struct {
+	GetF                                func(path string) ([]byte, *zk.Stat, error)
+	ExistsF                             func(path string) (bool, *zk.Stat, error)
+	CreateF                             func(path string, data []byte, flags int32, acl []zk.ACL) (string, error)
+	CreateProtectedEphemeralSequentialF func(path string, data []byte, acl []zk.ACL) (string, error)
+	ChildrenWF                          func(path string) ([]string, *zk.Stat, <-chan zk.Event, error)
+}
+
+// Get implements Conn.
+func (c ConnAdapter) Get(path string) ([]byte, *zk.Stat, error) {
+	return c.GetF(path)
+}
+
+// Exists implements Conn.
+func (c ConnAdapter) Exists(path string) (bool, *zk.Stat, error) {
+	return c.ExistsF(path)
+}
+
+// Create implements Conn.
+func (c ConnAdapter) Create(path string, data []byte, flags int32, acl []zk.ACL) (string, error) {
+	return c.CreateF(path, data, flags, acl)
+}
+
+// CreateProtectedEphemeralSequential implements Conn.
+func (c ConnAdapter) CreateProtectedEphemeralSequential(path string, data []byte, acl []zk.ACL) (string, error) {
+	return c.CreateProtectedEphemeralSequentialF(path, data, acl)
+}
+
+// ChildrenW implements Conn.
+func (c ConnAdapter) ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error) {
+	return c.ChildrenWF(path)
 }

--- a/elector/connector_existing.go
+++ b/elector/connector_existing.go
@@ -9,7 +9,7 @@ import "github.com/samuel/go-zookeeper/zk"
 //
 // The existing connection should have already established a session before
 // calling this method
-func ExistingConnection(conn *zk.Conn, events <-chan zk.Event) Connector {
+func ExistingConnection(conn Conn, events <-chan zk.Event) Connector {
 	return &existingConnection{
 		conn:   conn,
 		events: events,
@@ -17,11 +17,11 @@ func ExistingConnection(conn *zk.Conn, events <-chan zk.Event) Connector {
 }
 
 type existingConnection struct {
-	conn   *zk.Conn
+	conn   Conn
 	events <-chan zk.Event
 }
 
-func (e *existingConnection) Connect() (*zk.Conn, <-chan zk.Event, error) {
+func (e *existingConnection) Connect() (Conn, <-chan zk.Event, error) {
 	return e.conn, e.events, nil
 }
 

--- a/elector/connector_new.go
+++ b/elector/connector_new.go
@@ -45,7 +45,7 @@ type newConnection struct {
 	once  sync.Once
 }
 
-func (c *newConnection) Connect() (*zk.Conn, <-chan zk.Event, error) {
+func (c *newConnection) Connect() (Conn, <-chan zk.Event, error) {
 	connectTimeout := durationOrDefault(c.opts.ConnectTimeout, defaultConnectTimeout)
 	conn, zkEvents, err := zk.Connect(c.addrs, connectTimeout)
 	if err != nil {

--- a/elector/elector_test.go
+++ b/elector/elector_test.go
@@ -2,11 +2,13 @@ package elector
 
 import (
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/dcos/dcos-go/testutils"
 	"github.com/pkg/errors"
+	"github.com/samuel/go-zookeeper/zk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -189,4 +191,47 @@ func errMsg(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+func TestStart_NoDeadlock(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	events := make(chan zk.Event)
+	conn := ConnAdapter{
+		ExistsF: func(p string) (bool, *zk.Stat, error) {
+			defer wg.Done()
+			t.Logf("exists: %q", p)
+			// block until events is writable
+			events <- zk.Event{State: zk.StateSaslAuthenticated}
+			return true, nil, nil
+		},
+		CreateProtectedEphemeralSequentialF: func(string, []byte, []zk.ACL) (string, error) {
+			events <- zk.Event{State: zk.StateSaslAuthenticated}
+			return "protected", nil
+		},
+		ChildrenWF: func(string) ([]string, *zk.Stat, <-chan zk.Event, error) {
+			events <- zk.Event{State: zk.StateSaslAuthenticated}
+			return nil, nil, nil, nil
+		},
+	}
+	ctor := ExistingConnection(conn, events)
+	go func() {
+		defer wg.Done()
+		_, err := Start("id", "base", nil, ctor)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}()
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		wg.Wait()
+	}()
+	select {
+	case <-ch:
+		// we want this to happen because it means that
+		// initialize() isn't blocking event chan processing
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Start() to complete")
+	}
 }

--- a/zkstore/validate.go
+++ b/zkstore/validate.go
@@ -34,7 +34,7 @@ func ValidateNamed(name string, required bool) error {
 	return nil
 }
 
-// ValidateCategory: a category is required, and can look like a path or not.
+// ValidateCategory checks that a category is required, and can look like a path or not.
 func ValidateCategory(name string) error {
 	if strings.TrimSpace(name) == "" {
 		return errBadCategory


### PR DESCRIPTION
## Checklist
- [] ~80% unit test coverage?

## Overview of Change
* https://jira.mesosphere.com/browse/DSS_EE-101

## Affected Usage
Downstream projects that implement the `elector.Connector` API will need updates because the interface was made more generic.