### PR TITLE
Add missing DC/OS internal constants

### DIFF
--- a/dcos/constants.go
+++ b/dcos/constants.go
@@ -25,18 +25,3 @@ func GetFileDetectIPLocation() string {
 		return "/opt/mesosphere/bin/detect_ip"
 	}
 }
-
-// DC/OS DNS records.
-const (
-	// DNSRecordLeader is a domain name used by a leading master in DC/OS cluster.
-	DNSRecordLeader = "leader.mesos"
-)
-
-// DC/OS ports.
-const (
-	// PortMesosMaster defines a TCP port for mesos master.
-	PortMesosMaster = 5050
-
-	// PortMesosAgent defines a TCP port for mesos agent / public agent.
-	PortMesosAgent = 5051
-)

--- a/dcos/dns_records.go
+++ b/dcos/dns_records.go
@@ -1,0 +1,13 @@
+package dcos
+
+// DC/OS DNS records.
+const (
+	// DNSRecordLeader is a domain name used by the leading Mesos master in a DC/OS cluster.
+	DNSRecordLeader = "leader.mesos"
+
+	// DNSRecordMarathonLeader is the domain name used by the leading Marathon master.
+	DNSRecordMarathonLeader = "marathon.mesos"
+
+	// DNSRecordMasters is the domain name listing the connected masters in a DC/OS cluster.
+	DNSRecordMasters = "master.mesos"
+)

--- a/dcos/ports.go
+++ b/dcos/ports.go
@@ -1,0 +1,25 @@
+package dcos
+
+// DC/OS ports.
+const (
+	// PortExhibitor defines a TCP port for Exhibitor.
+	PortExhibitor = 8181
+
+	// PortHistoryService defines a TCP port for the DC/OS history service.
+	PortHistoryService = 15055
+
+	// PortMarathonHTTP defines a TCP port for Marathon.
+	PortMarathonHTTP = 8080
+
+	// PortMesosAgent defines a TCP port for mesos agent / public agent.
+	PortMesosAgent = 5051
+
+	// PortMesosDNS defines a TCP port for MesosDNS.
+	PortMesosDNS = 8123
+
+	// PortMesosMaster defines a TCP port for mesos master.
+	PortMesosMaster = 5050
+
+	// PortMetronomeHTTP defines a TCP port for Metronome.
+	PortMetronomeHTTP = 9090
+)


### PR DESCRIPTION
# Add missing DC/OS internal port constants
## Checklist
- [] ~80% unit test coverage?
- [] Updated [README.md](README.md)?
- [x] Completed sections of this PR template?
- [x] Edited all sections [IN BRACKETS]

## Overview of Change
Multiple DC/OS checks access the DC/OS internal HTTP servers on those pre-defined ports.
Also having multiple projects using those ports, they should not be re-defined in every repository.
Having a single location for the port constants makes it easier to maintain them.

## Affected Usage
This should be the default location that DC/OS ports are referenced from so that in case of a change
it only needs to be changed in one location.
