### PR TITLE
Add Adminrouter HTTP port constant

### DIFF
--- a/dcos/ports.go
+++ b/dcos/ports.go
@@ -2,6 +2,9 @@ package dcos
 
 // DC/OS ports.
 const (
+	// PortAdminrouterHTTP defines a TCP port for Adminrouter.
+	PortAdminrouterHTTP = 80
+
 	// PortExhibitor defines a TCP port for Exhibitor.
 	PortExhibitor = 8181
 
@@ -11,13 +14,13 @@ const (
 	// PortMarathonHTTP defines a TCP port for Marathon.
 	PortMarathonHTTP = 8080
 
-	// PortMesosAgent defines a TCP port for mesos agent / public agent.
+	// PortMesosAgent defines a TCP port for Mesos on agent / public agent nodes.
 	PortMesosAgent = 5051
 
 	// PortMesosDNS defines a TCP port for MesosDNS.
 	PortMesosDNS = 8123
 
-	// PortMesosMaster defines a TCP port for mesos master.
+	// PortMesosMaster defines a TCP port for Mesos on master nodes.
 	PortMesosMaster = 5050
 
 	// PortMetronomeHTTP defines a TCP port for Metronome.


### PR DESCRIPTION
# Add Adminrouter HTTP port constant
## Checklist
- [] ~80% unit test coverage?
- [] Updated [README.md](README.md)?
- [x] Completed sections of this PR template?
- [x] Edited all sections [IN BRACKETS]

## Overview of Change
Adding missing DC/OS ports so that they only reside in one place.

## Affected Usage
This is part of the attempt to make this the central Go library for interacting with DC/OS.
