### PR TITLE
zkutils: auto remove the ZK docker container

### DIFF
--- a/testutils/zk_utils.go
+++ b/testutils/zk_utils.go
@@ -54,7 +54,9 @@ func StartZookeeper(opts ...func(*ZKConfig)) (*ZkControl, error) {
 
 	// the container IP is not routable on Darwin, thus needs port
 	// mapping for the container.
-	hostConfig := &container.HostConfig{}
+	hostConfig := &container.HostConfig{
+		AutoRemove: true,
+	}
 	if runtime.GOOS == "darwin" {
 		hostConfig.PortBindings = nat.PortMap{
 			nat.Port(fmt.Sprintf("%d/tcp", config.ClientPort)): []nat.PortBinding{{


### PR DESCRIPTION


# zkutils: auto remove the ZK docker container
## Checklist
- [] ~80% unit test coverage?
- [] Updated [README.md](README.md)?
- [] Completed sections of this PR template?
- [] Edited all sections [IN BRACKETS]

## Overview of Change

This is for the case where the test process is killed, leaving the ZK
container running. It'll be great if `docker stop` can also remove the
container as well.

### Changelog [optional]
- [] [optional list]

## Affected Usage

ZK container will be auto removed if stopped.
