### PR TITLE
Fix Windows unittests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+*.go        text eol=lf
+*.ps1       text eol=crlf
+*.psm1      text eol=crlf
+*.psd1      text eol=crlf

--- a/zkstore/store_test.go
+++ b/zkstore/store_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package zkstore
 
 import (


### PR DESCRIPTION
# Fix failing Windows unit tests

## Overview of Change
Some of the tests that run on Jenkins Windows Slaves fail:

- The diff from gofmt command throws errors because of different OS line endings 
              -> Add .gitattributes file
- The docker image used for zkstore tests is a Linux docker image 
              -> Skip those tests on Windows

## Affected Usage
Some of the zookeeper tests that are using a linux docker image will not run on Windows

