### PR TITLE
Fix go imports

### DIFF
--- a/dcos/nodeutil/util_test.go
+++ b/dcos/nodeutil/util_test.go
@@ -1,16 +1,15 @@
 package nodeutil
 
 import (
+	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
-	"testing"
-
-	"context"
-	"io/ioutil"
 	"strings"
+	"testing"
 
 	"github.com/dcos/dcos-go/dcos"
 )

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -47,7 +47,7 @@ function _goimports()
 function _golint()
 {
     logmsg("Running 'golint' ...")
-    & go get -u github.com/golang/lint/golint
+    & go get -u golang.org/x/lint/golint
 
     $text = & golint -set_exit_status  $PACKAGES
     fastfail("failed to run golint: $text")


### PR DESCRIPTION
# Fix go imports and golint import path


## Overview of Change
Re-ordered go imports to fix test errors
Fixed golint import path error introduced with:
https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58

