### PR TITLE
Add User-Agent header to requests

### DIFF
--- a/dcos/http/transport/README.md
+++ b/dcos/http/transport/README.md
@@ -4,6 +4,6 @@
 - package breaks `RoundTripper` interface spec defined in `https://golang.org/pkg/net/http/#RoundTripper`
   by mutating request instance.
 
-jwt/transport is an http.RoundTripper implementation that automatically adds `Authorization` header to each request with
-a signed token. If request returns 401 response code, the library will generate a new token, sign it with a bouncer and
-retry the current request.
+jwt/transport is an http.RoundTripper implementation that automatically adds `User-Agent` and `Authorization` headers
+to each request with a signed token. If request returns 401 response code, the library will generate a new token, sign
+it with a bouncer and retry the current request.

--- a/dcos/http/transport/README.md
+++ b/dcos/http/transport/README.md
@@ -4,6 +4,7 @@
 - package breaks `RoundTripper` interface spec defined in `https://golang.org/pkg/net/http/#RoundTripper`
   by mutating request instance.
 
-jwt/transport is an http.RoundTripper implementation that automatically adds `User-Agent` and `Authorization` headers
-to each request with a signed token. If request returns 401 response code, the library will generate a new token, sign
+jwt/transport is an http.RoundTripper implementation that adds `Authorization` and `User-Agent` headers to each
+request. The `Authorization` header is a signed Javascript web token (JWT). The `User-Agent` defaults to
+`dcos-go`, and may be customized. If request returns 401 response code, the library will generate a new token, sign
 it with a bouncer and retry the current request.

--- a/dcos/http/transport/option.go
+++ b/dcos/http/transport/option.go
@@ -29,6 +29,9 @@ var (
 	// ErrInvalidCredentials is the error returned by NewRoundTripper if user used empty string for a credentials.
 	ErrInvalidCredentials = errors.New("uid, secret and loginEndpoit cannot be empty")
 
+	// ErrInvalidUserAgent is the error returned by NewRoundTripper if user used empty string for a user agent.
+	ErrInvalidUserAgent = errors.New("userAgent cannot be empty")
+
 	// ErrInvalidExpireDuration is the error returned by NewRoundTripper if the token expire duration is negative or
 	// zero value.
 	ErrInvalidExpireDuration = errors.New("token expire duration must be positive non zero value")
@@ -105,6 +108,17 @@ func OptionCredentials(uid, secret, loginEndpoint string) OptionRoundtripperFunc
 		}
 
 		return ErrInvalidCredentials
+	}
+}
+
+// OptionUserAgent is an option to set userAgent
+func OptionUserAgent(userAgent string) OptionRoundtripperFunc {
+	return func(j *dcosRoundtripper) error {
+		if userAgent == "" {
+			return ErrInvalidUserAgent
+		}
+		j.userAgent = userAgent
+		return nil
 	}
 }
 

--- a/dcos/http/transport/roundtripper.go
+++ b/dcos/http/transport/roundtripper.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -174,8 +173,8 @@ func (t *dcosRoundtripper) CurrentToken() string {
 
 // RoundTrip is implementation of RoundTripper interface.
 func (t *dcosRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Set `User-Agent` header, defaulting to process name
-	userAgent := os.Args[0]
+	// Set `User-Agent` header, defaulting to `dcos-go`
+	userAgent := "dcos-go"
 	if t.userAgent != "" {
 		userAgent = t.userAgent
 	}

--- a/dcos/http/transport/roundtripper.go
+++ b/dcos/http/transport/roundtripper.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -50,6 +51,7 @@ type dcosRoundtripper struct {
 	token              string
 	expire             time.Duration
 	uid, loginEndpoint string
+	userAgent          string
 	secret             *rsa.PrivateKey
 	transport          http.RoundTripper
 }
@@ -172,6 +174,13 @@ func (t *dcosRoundtripper) CurrentToken() string {
 
 // RoundTrip is implementation of RoundTripper interface.
 func (t *dcosRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Set `User-Agent` header, defaulting to process name
+	userAgent := os.Args[0]
+	if t.userAgent != "" {
+		userAgent = t.userAgent
+	}
+	req.Header.Set("User-Agent", userAgent)
+
 	// helper function to update `Authorization` header.
 	addAuthToken := func() {
 		if token := t.CurrentToken(); token != "" {
@@ -203,6 +212,7 @@ func (t *dcosRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) 
 			return nil, err
 		}
 	}
+
 	return resp, nil
 }
 


### PR DESCRIPTION
# Add User-Agent header to requests

note: windows build will fail until https://jira.mesosphere.com/browse/DCOS-44309 is resolved

## Checklist
- [] ~80% unit test coverage?
- [x] Updated [README.md](README.md)?
- [x] Completed sections of this PR template?
- [x] Edited all sections [IN BRACKETS]

## Overview of Change
https://jira.mesosphere.com/browse/DCOS_OSS-4168
It would be valuable to send a `User-Agent` with requests to correlate them with the originator. The `User-Agent` defaults to `dcos-go` if one is not passed through using [`OptionUserAgent`](https://github.com/dcos/dcos-go/compare/gracedo/add_user_agent_header?expand=1#diff-15f81910753ae4f24ad4f94b11f3bde1R115)

## Affected Usage
A `User-Agent` header will be sent along with all requests going through this transport.